### PR TITLE
monitoring: wait for grafana task

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -67,6 +67,16 @@
     regexp: '\$\{DS_PROMETHEUS\}'
     replace: 'prometheus'
 
+- name: wait for the grafana to be ready
+  ansible.builtin.uri:
+    url: "https://{{ monitoring.server_name }}/api/health"
+    method: GET
+  register: grafana_health
+  until: grafana_health.status==200
+  retries: 30
+  delay: 5
+  when: absent_or_present=="present"
+
 - name: Import resulting dashboard in Grafana
   community.grafana.grafana_dashboard:
     grafana_url: "https://{{ monitoring.server_name }}"


### PR DESCRIPTION
Add a task to wait for grafana to be up and running before importing the dashboard.

Tested deploying lagraulet env from scratch