### PR TITLE
freeze chart versions

### DIFF
--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -25,6 +25,7 @@ prosante_connect:
   client_id: ${PROSANTE_CONNECT_CLIENT_ID}
   client_secret: ${PROSANTE_CONNECT_CLIENT_SECRET}
 matrix:
+  chart_version: "3.7.7"
   server_name: ${SERVER_SUBDOMAIN_NAME}.${ENV_IN_URL}.${DNS_ZONE}
   smtp_host: ${SMTP_HOST}
 # FIXME smtp_port set with ansible variable is consider as string and not int
@@ -52,6 +53,7 @@ matrix:
     secret_key: ${S3_MEDIA_REPO_SECRET_KEY}
     module_version: "v1.2.1"
 element:
+  chart_version: "1.3.2"
   server_name: ${ELEMENT_SUBDOMAIN_NAME}.${ENV_IN_URL}.${DNS_ZONE}
 msteams:
   enabled: ${TEAMS_BRIDGE_ENABLED}
@@ -60,7 +62,7 @@ msteams:
     client_id: ${TEAMS_OAUTH_CLIENT_ID}
     client_secret: ${TEAMS_OAUTH_CLIENT_SECRET}
 monitoring:
-  kube_prometheus_version: v0.12.0
+  chart_version: "51.2.0"
   kube_prometheus_git_url: "https://github.com/prometheus-operator/kube-prometheus.git"
   server_name: ${MONITORING_SUBDOMAIN_NAME}.${ENV_IN_URL}.${DNS_ZONE}
   grafana_password: ${MONITORING_GRAFANA_PASSWORD}

--- a/ansible/roles/element-web/tasks/main.yml
+++ b/ansible/roles/element-web/tasks/main.yml
@@ -3,6 +3,7 @@
   kubernetes.core.helm:
     name: element-web
     chart_ref: ananace-charts/element-web
+    chart_version: {{ element.chart_version }}
     release_state: "{{ absent_or_present }}"
     release_namespace: element-web
     create_namespace: true

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -13,6 +13,7 @@
   kubernetes.core.helm:
     name: kube-prometheus
     chart_ref: prometheus-community/kube-prometheus-stack
+    chart_version: "{{ monitoring.chart_version }}"
     release_namespace: monitoring
     create_namespace: true
     release_values:

--- a/ansible/roles/synapse/tasks/main.yml
+++ b/ansible/roles/synapse/tasks/main.yml
@@ -44,6 +44,7 @@
   kubernetes.core.helm:
     name: matrix-synapse
     chart_ref: ananace-charts/matrix-synapse
+    chart_version: "{{ matrix.chart_version }}"
     release_state: "{{ absent_or_present }}"
     release_namespace: default
     release_values:


### PR DESCRIPTION
Add chart versions in ansible variable template file.

(`kube_prometheus_version` wasn't used)

Tested on a recently deployed env : nothing changed.