### PR TITLE
fix: 1mb max upload size and parametrize it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ env:
   DUMMY_PASSWORD: ${{ secrets.DUMMY_PASSWORD }}
   FEDERATION_SERVERS_LIST: ${{ vars.FEDERATION_SERVERS_LIST }}
   SYNAPSE_AUTO_REGISTRATION: ${{ vars.SYNAPSE_AUTO_REGISTRATION }}
+  SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ENABLED: ${{ vars.PROSANTE_CONNECT_ENABLED }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -67,6 +67,7 @@ env:
   DUMMY_PASSWORD: ${{ secrets.DUMMY_PASSWORD }}
   FEDERATION_SERVERS_LIST: ${{ vars.FEDERATION_SERVERS_LIST }}
   SYNAPSE_AUTO_REGISTRATION: ${{ vars.SYNAPSE_AUTO_REGISTRATION }}
+  SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ISSUER: ${{ vars.PROSANTE_CONNECT_ISSUER }}

--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -42,6 +42,7 @@ matrix:
   dummy_username: ${DUMMY_USERNAME}
   dummy_password: ${DUMMY_PASSWORD}
   auto_registration: ${SYNAPSE_AUTO_REGISTRATION}
+  media_upload_max_size_mb: ${SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB}
   servers_list: ${FEDERATION_SERVERS_LIST}
   s3_media_repo:
     region: ${S3_REGION}

--- a/ansible/roles/synapse/templates/synapse-chart-config.j2
+++ b/ansible/roles/synapse/templates/synapse-chart-config.j2
@@ -45,6 +45,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: "{{ matrix.server_name }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ matrix.media_upload_max_size_mb }}m
   tls:
     - hosts:
         - "{{ matrix.server_name }}"
@@ -54,6 +55,7 @@ wellknown:
 extraConfig:
   allow_public_rooms_over_federation: true
   enable_registration_without_verification: false
+  max_upload_size: {{ matrix.media_upload_max_size_mb }}M
   registrations_require_3pid:
     - email
   email:

--- a/scripts/local.env.template.sh
+++ b/scripts/local.env.template.sh
@@ -71,6 +71,7 @@ export DUMMY_USERNAME="<dummy user used with the discovery room mecanism>"
 export DUMMY_PASSWORD="<password for the dummy user>"
 export FEDERATION_SERVERS_LIST="<list of comma separated URI of synapse servers included in federation. Ex : ['preprod.eimis.incubateur.net','matrix.pandalab.fr']>"
 export SYNAPSE_AUTO_REGISTRATION="<if set to true, users can auto register. If set to false, they can only be registered by admin>"
+export SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB="<max size of media in MB>"
 # variables used to connect to Pro Santé Connect.
 # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
 export PROSANTE_CONNECT_ENABLED="<true to login with PSC>"


### PR DESCRIPTION
Regards #279:

Specify a body max size in synapse ingress to fix larger than 1mb file upload.

Parametrize this max size to fit Synapse config option.

Lagraulet tested. 