### PR TITLE
Add a welcome room

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ env:
   FEDERATION_SERVERS_LIST: ${{ vars.FEDERATION_SERVERS_LIST }}
   SYNAPSE_AUTO_REGISTRATION: ${{ vars.SYNAPSE_AUTO_REGISTRATION }}
   SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
+  SYNAPSE_WELCOME_ROOM: ${{ vars.SYNAPSE_WELCOME_ROOM }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ENABLED: ${{ vars.PROSANTE_CONNECT_ENABLED }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -68,6 +68,7 @@ env:
   FEDERATION_SERVERS_LIST: ${{ vars.FEDERATION_SERVERS_LIST }}
   SYNAPSE_AUTO_REGISTRATION: ${{ vars.SYNAPSE_AUTO_REGISTRATION }}
   SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
+  SYNAPSE_WELCOME_ROOM: ${{ vars.SYNAPSE_WELCOME_ROOM }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ISSUER: ${{ vars.PROSANTE_CONNECT_ISSUER }}

--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -43,6 +43,7 @@ matrix:
   dummy_password: ${DUMMY_PASSWORD}
   auto_registration: ${SYNAPSE_AUTO_REGISTRATION}
   media_upload_max_size_mb: ${SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB}
+  welcome_room: ${SYNAPSE_WELCOME_ROOM}
   servers_list: ${FEDERATION_SERVERS_LIST}
   s3_media_repo:
     region: ${S3_REGION}

--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -32,12 +32,6 @@ data:
             email_template: "{% raw %}{{ user.email }}{% endraw %}"
         backchannel_logout_enabled: true # Optional
 {% endif %}
-    auto_join_rooms: 
-      - "#discoveryroom:{{ matrix.server_name }}"
-{% if matrix.welcome_room is defined %}
-      - "#{{ matrix.welcome_room }}:{{ matrix.server_name }}"
-{% endif %}
-    autocreate_auto_join_rooms: true
 {% if matrix.servers_list is defined %}
     federation_domain_whitelist: {{ matrix.servers_list }}
 {% endif %}

--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -32,7 +32,11 @@ data:
             email_template: "{% raw %}{{ user.email }}{% endraw %}"
         backchannel_logout_enabled: true # Optional
 {% endif %}
-    auto_join_rooms: ["#discoveryroom:{{ matrix.server_name }}"]
+    auto_join_rooms: 
+      - "#discoveryroom:{{ matrix.server_name }}"
+{% if matrix.welcome_room is defined %}
+      - "#{{ matrix.welcome_room }}:{{ matrix.server_name }}"
+{% endif %}
     autocreate_auto_join_rooms: true
 {% if matrix.servers_list is defined %}
     federation_domain_whitelist: {{ matrix.servers_list }}

--- a/ansible/roles/synapse/templates/synapse-chart-config.j2
+++ b/ansible/roles/synapse/templates/synapse-chart-config.j2
@@ -64,6 +64,11 @@ extraConfig:
     smtp_user: "{{ matrix.smtp_user }}"
     smtp_pass: "{{ matrix.smtp_pass }}"
     notif_from: "{{ matrix.notify_from }}"
+  auto_join_rooms: 
+      - "#discoveryroom:{{ matrix.server_name }}"
+{% if matrix.welcome_room is defined %}
+      - "#{{ matrix.welcome_room }}:{{ matrix.server_name }}"
+{% endif %}
 {% if msteams.enabled %}
   app_service_config_files:
     - /synapse/config/appservices/msteams-registration.yaml

--- a/scripts/local.env.template.sh
+++ b/scripts/local.env.template.sh
@@ -72,6 +72,7 @@ export DUMMY_PASSWORD="<password for the dummy user>"
 export FEDERATION_SERVERS_LIST="<list of comma separated URI of synapse servers included in federation. Ex : ['preprod.eimis.incubateur.net','matrix.pandalab.fr']>"
 export SYNAPSE_AUTO_REGISTRATION="<if set to true, users can auto register. If set to false, they can only be registered by admin>"
 export SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB="<max size of media in MB>"
+export SYNAPSE_WELCOME_ROOM="<alias of a room that will be joined by default by every user. ex: 'welcome-room'. Optional>"
 # variables used to connect to Pro Santé Connect.
 # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
 export PROSANTE_CONNECT_ENABLED="<true to login with PSC>"


### PR DESCRIPTION
Related to #271 

In order to be notified when a user registers to one of our instances, this PR introduces the possibility to configure a welcome room in which all users will be joined by default.

If the configured room does not exists, it is created during first user registration (admin user). So if the instance is not created from scratch, the room has to be created manually.