### PR TITLE
Manage logout when logged with keycloak

### DIFF
--- a/ansible/roles/element-web/tasks/main.yml
+++ b/ansible/roles/element-web/tasks/main.yml
@@ -16,6 +16,8 @@
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header Content-Security-Policy "frame-ancestors 'self'";
+      config:
+        logout_redirect_url: "https://{{ keycloak.server_name }}/realms/eimis-realm/protocol/openid-connect/logout?post_logout_redirect_uri=https://{{ element.server_name }}&client_id={{ keycloak.client_id }}"
       ingress:
         enabled: true
         className: nginx

--- a/ansible/roles/keycloak/templates/keycloak-realm.yml
+++ b/ansible/roles/keycloak/templates/keycloak-realm.yml
@@ -25,7 +25,8 @@ spec:
         protocol: "openid-connect"
         attributes:
           login_theme: "keycloak"
-          post.logout.redirect.uris: "/_synapse/client/oidc/backchannel_logout"
+          post.logout.redirect.uris: "https://{{ matrix.server_name }}*"
+          backchannel.logout.url: "https://{{ matrix.server_name }}/_synapse/client/oidc/backchannel_logout"
     smtpServer:
       auth: "true"
       envelopeFrom: ""


### PR DESCRIPTION
#346 

### Properly manage logout:

- user is logged out when the session is ended in keycloak
- user is redirected to keycloak after element logout and if the user doesn't log out from keycloak he/she can log in again without error

Tested and available on lagraulet environment