### PR TITLE
latest image for develop and french keycloak realm

### DIFF
--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -56,6 +56,7 @@ matrix:
   dummy_username: ${DUMMY_USERNAME}
   dummy_password: ${DUMMY_PASSWORD}
   auto_registration: ${SYNAPSE_AUTO_REGISTRATION}
+  password_config: ${SYNAPSE_ENABLE_PASSWORD_LOGIN}
   media_upload_max_size_mb: ${SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB}
   welcome_room: ${SYNAPSE_WELCOME_ROOM}
   servers_list: ${FEDERATION_SERVERS_LIST}

--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -15,6 +15,7 @@ external_dns:
   registry_id: ${ENVIRONMENT}
 keycloak:
   server_name: ${KEYCLOAK_SUBDOMAIN_NAME}.${ENV_IN_URL}.${DNS_ZONE}
+  image_tag: ${KEYCLOAK_IMAGE_TAG}
   operator_version : 23.0.3
   db_user: "keycloak"
   db_password: ${KEYCLOAK_DB_PASSWORD}
@@ -34,7 +35,7 @@ prosante_connect:
   client_secret: ${PROSANTE_CONNECT_CLIENT_SECRET}
 matrix:
   chart_version: "3.7.14"
-  image_version: "1.98.0-1"
+  image_tag: ${SYNAPSE_IMAGE_TAG}
   server_name: ${SERVER_SUBDOMAIN_NAME}.${ENV_IN_URL}.${DNS_ZONE}
   smtp_host: ${SMTP_HOST}
 # FIXME smtp_port set with ansible variable is consider as string and not int

--- a/ansible/roles/keycloak/templates/keycloak-realm.yml
+++ b/ansible/roles/keycloak/templates/keycloak-realm.yml
@@ -10,6 +10,11 @@ spec:
     realm: eimis-realm
     displayName: "Eimis Connect"
     enabled: true
+    internationalizationEnabled: true
+    supportedLocales:
+      - "en"
+      - "fr"
+    defaultLocale: "fr"
     clients:
       - clientId: "{{ keycloak.client_id }}"
         name: "synapsecret"

--- a/ansible/roles/keycloak/templates/keycloak.yml.j2
+++ b/ansible/roles/keycloak/templates/keycloak.yml.j2
@@ -7,7 +7,7 @@ metadata:
     app: keycloak-eimis
 spec:
   instances: 1
-  image: eimisans/eimis-keycloak:23.0.3-3
+  image: eimisans/eimis-keycloak:{{ keycloak.image_tag }}
   hostname:
     hostname: "{{ keycloak.server_name }}"
     strict: false

--- a/ansible/roles/synapse/templates/synapse-chart-config.j2
+++ b/ansible/roles/synapse/templates/synapse-chart-config.j2
@@ -1,6 +1,6 @@
 image:
   repository: eimisans/synapse
-  tag: {{ matrix.image_version }}
+  tag: {{ matrix.image_tag }}
 synapse:
   strategy:
     type: Recreate

--- a/ansible/roles/synapse/templates/synapse-chart-config.j2
+++ b/ansible/roles/synapse/templates/synapse-chart-config.j2
@@ -53,6 +53,8 @@ wellknown:
 extraConfig:
   allow_public_rooms_over_federation: true
   enable_registration_without_verification: false
+  password_config:
+    enabled: {{ matrix.password_config }}
   max_upload_size: {{ matrix.media_upload_max_size_mb }}M
   registrations_require_3pid:
     - email

--- a/scripts/local.env.template.sh
+++ b/scripts/local.env.template.sh
@@ -72,6 +72,7 @@ export DUMMY_USERNAME="<dummy user used with the discovery room mecanism>"
 export DUMMY_PASSWORD="<password for the dummy user>"
 export FEDERATION_SERVERS_LIST="<list of comma separated URI of synapse servers included in federation. Ex : ['preprod.eimis.incubateur.net','matrix.pandalab.fr']>"
 export SYNAPSE_AUTO_REGISTRATION="<if set to true, users can auto register. If set to false, they can only be registered by admin>"
+export SYNAPSE_ENABLE_PASSWORD_LOGIN="<`true`: users can login with password.`false`, they can only login with SSO>"
 export SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB="<max size of media in MB>"
 export SYNAPSE_WELCOME_ROOM="<alias of a room that will be joined by default by every user. ex: 'welcome-room'. Optional>"
 # variables used to connect to Pro Santé Connect.


### PR DESCRIPTION
Some minor improvements:

- Have keycloak language be french by default
- Parametrize Synapse and keycloak version, so that develop env can have latest image without needing a pull requests
- Parametrize login with password so we can have it disabled for develop and prod and enabled in preprod as some users are already registered

Will resolve #353 and #341