### PR TITLE
Avoid pinging vector.im on element-web

### DIFF
--- a/ansible/roles/element-web/tasks/main.yml
+++ b/ansible/roles/element-web/tasks/main.yml
@@ -11,6 +11,8 @@
       defaultServer:
         url: "https://{{ matrix.server_name }}"
         name: "{{ matrix.server_name }}"
+        #  if not set or "", helm chart sets it to vector.im. Space here avoids overriding configuration along with the identity server unreachable warning on login page
+        identity_url: " "
       nginxConfig: |-
         add_header X-Frame-Options SAMEORIGIN;
         add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
#385

We shouldn't use `vector.im` as identity server for our purpose but the helm chart sets it by default if not  set or empty. This PR does the trick : no ping to vector.im and no `unreachable identity server` warning on the login page