### PR TITLE
fix: openssl command to generate hmac with last version of openssl lib

### DIFF
--- a/ansible/roles/discovery-rooms/tasks/dummy-user.yml
+++ b/ansible/roles/discovery-rooms/tasks/dummy-user.yml
@@ -16,7 +16,7 @@
     admin='notadmin'
     secret='{{ registration_shared_secret.stdout }}'
     printf '%s\0%s\0%s\0%s' "$nonce" "$username" "$password" "$admin" |
-    openssl sha1 -hmac "$secret" |
+    openssl dgst -sha1 -hmac "$secret" |
     awk '{print $2}'
   register: hmac
 

--- a/ansible/roles/first-admin/tasks/main.yml
+++ b/ansible/roles/first-admin/tasks/main.yml
@@ -20,7 +20,7 @@
     admin='admin'
     secret='{{ registration_shared_secret.stdout }}'
     printf '%s\0%s\0%s\0%s' "$nonce" "$username" "$password" "$admin" |
-    openssl sha1 -hmac "$secret" |
+    openssl dgst -sha1 -hmac "$secret" |
     awk '{print $2}'
   register: hmac
 


### PR DESCRIPTION
To fix prod deployment (openssl version : 3.0.7).
Tested on local linux (3.0.2) and on github runner.