### PR TITLE
feat: use EIMIS Synapse modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,7 @@ env:
   SYNAPSE_IMAGE_TAG: ${{ vars.SYNAPSE_IMAGE_TAG }}
   SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
   SYNAPSE_WELCOME_ROOM: ${{ vars.SYNAPSE_WELCOME_ROOM }}
+  SYNAPSE_WHITELIST_ROOM: ${{ vars.SYNAPSE_WHITELIST_ROOM }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ENABLED: ${{ vars.PROSANTE_CONNECT_ENABLED }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -89,6 +89,7 @@ env:
   SYNAPSE_IMAGE_TAG: ${{ vars.SYNAPSE_IMAGE_TAG }}
   SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB: ${{ vars.SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB }}
   SYNAPSE_WELCOME_ROOM: ${{ vars.SYNAPSE_WELCOME_ROOM }}
+  SYNAPSE_WHITELIST_ROOM: ${{ vars.SYNAPSE_WHITELIST_ROOM }}
   # variables used to connect to Pro Santé Connect.
   # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
   PROSANTE_CONNECT_ENABLED: ${{ vars.PROSANTE_CONNECT_ENABLED }}

--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -59,6 +59,7 @@ matrix:
   media_upload_max_size_mb: ${SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB}
   welcome_room: ${SYNAPSE_WELCOME_ROOM}
   servers_list: ${FEDERATION_SERVERS_LIST}
+  whitelist_room: ${SYNAPSE_WHITELIST_ROOM}
   s3_media_repo:
     region: ${S3_REGION}
     bucket_name: ${S3_MEDIA_BUCKET_NAME}

--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -38,7 +38,9 @@ data:
         client_id: "{{ prosante_connect.client_id }}"
         client_secret: "{{ prosante_connect.client_secret }}"
         scopes: ["openid", "scope_all"]
+        user_profile_method: userinfo_endpoint
         user_mapping_provider:
+          module: synapse.psc_mapping_provider.ProsanteConnectMappingProvider
           config:
             localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
             display_name_template: "{% raw %}{{ user.given_name }} {{ user.family_name }}{% endraw %}"
@@ -48,6 +50,11 @@ data:
 {% if matrix.servers_list is defined %}
     federation_domain_whitelist: {{ matrix.servers_list }}
 {% endif %}
+    modules:
+      - module: white_list_module.EimisWhiteList
+        config:
+          room_id: "{{ matrix.whitelist_room }}"
+          idp_id: "psc"
     media_storage_providers:
       - module: s3_storage_provider.S3StorageProviderBackend
         store_local: True

--- a/scripts/local.env.template.sh
+++ b/scripts/local.env.template.sh
@@ -92,6 +92,7 @@ export SYNAPSE_ENABLE_PASSWORD_LOGIN="<`true`: users can login with password.`fa
 export SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB="<max size of media in MB>"
 export SYNAPSE_WELCOME_ROOM="<alias of a room that will be joined by default by every user. ex: 'welcome-room'. Optional>"
 export SYNAPSE_IMAGE_TAG="<docker image tag>"
+export SYNAPSE_WHITELIST_ROOM="<room id used to store user whitelist>"
 # variables used to connect to Pro Santé Connect.
 # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
 export PROSANTE_CONNECT_ENABLED="<true to login with PSC>"


### PR DESCRIPTION
#343 and #404 

Make good use of[ prosante connect mapper](https://github.com/eimis-ans/eimis-prosante-connect-module) and user [whitelist module](https://github.com/eimis-ans/white-list-synapse-module).

Tested on lagraulet env with manual image building but will only worked after eimisans/synapse tag 1.104.0.1

- [x] Need the creation of white list room and a `SYNAPSE_WHITELIST_ROOM` env var