### PR TITLE
Configure display name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ On the linux running this code :
 - the [terraform CLI](https://developer.hashicorp.com/terraform/downloads?product_intent=terraform)
 - the [ansible tool](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible)
 - the [kubectl tool](https://kubernetes.io/fr/docs/tasks/tools/install-kubectl/)
+- additional needed packages : `openssl`, `yq`
 
 ## Provisioning infra
 
@@ -83,7 +84,7 @@ and fill it with all the environment variables values needed. `OS_`variables rel
 The configuration part will be done with Ansible and is quite independent
 from the provisioning part.
 
-- Generate the files (kubeconfig.yml, ansible/group_vars/all.yml) and vars needed :
+- Generate the files (kubeconfig-$ENVIRONMENT.yml, ansible/group_vars/all.yml) and vars needed :
 
   ```bash
   ./scripts/generate_configuration_var_files.sh

--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -59,6 +59,7 @@ matrix:
   enable_change_displayname: ${SYNAPSE_ENABLE_CHANGE_DISPLAYNAME}
   media_upload_max_size_mb: ${SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB}
   welcome_room: ${SYNAPSE_WELCOME_ROOM}
+  default_eimis_name_suffix: ${DEFAULT_EIMIS_NAME_SUFFFIX}
   servers_list: ${FEDERATION_SERVERS_LIST}
   whitelist_room: ${SYNAPSE_WHITELIST_ROOM}
   s3_media_repo:

--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -23,10 +23,12 @@ data:
         client_secret: "{{ keycloak.client_secret }}"
         scopes: ["openid", "profile"]
         user_mapping_provider:
+          module: synapse.psc_mapping_provider.ProsanteConnectMappingProvider
           config:
             localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
             display_name_template: "{% raw %}{{ user.given_name }} {{ user.family_name }}{% endraw %}"
             email_template: "{% raw %}{{ user.email }}{% endraw %}"
+            default_display_name_suffix: "{{ matrix.default_eimis_name_suffix }}"
         backchannel_logout_enabled: true # Optional
 {% if prosante_connect.enabled  %}
       - idp_id: psc
@@ -48,6 +50,7 @@ data:
             localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
             display_name_template: "{% raw %}{{ user.given_name }} {{ user.family_name }}{% endraw %}"
             email_template: "{% raw %}{{ user.email }}{% endraw %}"
+            default_display_name_suffix: "{{ matrix.default_eimis_name_suffix }}"
         backchannel_logout_enabled: true # Optional
 {% endif %}
 {% if matrix.servers_list is defined %}

--- a/scripts/local.env.template.sh
+++ b/scripts/local.env.template.sh
@@ -94,6 +94,7 @@ export SYNAPSE_MEDIA_UPLOAD_MAX_SIZE_MB="<max size of media in MB>"
 export SYNAPSE_WELCOME_ROOM="<alias of a room that will be joined by default by every user. ex: 'welcome-room'. Optional>"
 export SYNAPSE_IMAGE_TAG="<docker image tag>"
 export SYNAPSE_WHITELIST_ROOM="<room id used to store user whitelist>"
+export DEFAULT_EIMIS_NAME_SUFFFIX="<when using eimis prosante connect module, sets a default suffix to add to the display name when activity is missing from ID provider userInfo ex: ' - 🧡'>"
 # variables used to connect to Pro Santé Connect.
 # see : https://industriels.esante.gouv.fr/produits-et-services/pro-sante-connect/documentation-technique
 export PROSANTE_CONNECT_ENABLED="<true to login with PSC>"


### PR DESCRIPTION
Use ProsanteConnectMappingProvider module for EIMIS connect.
In the last version, it's possible to define a default suffix to add to display name if the profession as not been found in user info. Allowing users to easily identify people using PSC id provider.

The viariable is called `DEFAULT_EIMIS_NAME_SUFFFIX`

Tested  on `lagraulet` env

#400