### PR TITLE
Resolve load balancer instability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.*
+          terraform_version: 1.9.*
 
       # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
       - name: Terraform Init
@@ -243,7 +243,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: 1.7.*
+          terraform_version: 1.9.*
 
       - name: Terraform Init
         run: cd terraform && terraform init -backend-config="bucket=terraform-states-hp-${{ needs.set_environment.outputs.my_env }}"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.*
+          terraform_version: 1.9.*
 
       # Generates a terraform.tfvars file from the environment variables
       - name: Generate tfvars file

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.*
+          terraform_version: 1.9.*
 
       - name: Terraform Init
         run: cd terraform && terraform init -backend=false

--- a/.github/workflows/trivy-report.yml
+++ b/.github/workflows/trivy-report.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.*
+          terraform_version: 1.9.*
 
       - name: Terraform Init
         run: |

--- a/ansible/roles/admin_vm_zabbix/tasks/main.yml
+++ b/ansible/roles/admin_vm_zabbix/tasks/main.yml
@@ -4,6 +4,7 @@
     repo: 'https://github.com/zabbix/zabbix-docker.git'
     dest: ./zabbix-docker
     version: 7.0
+    force: true
 
 - name: Launch Zabbix with docker-compose
   community.docker.docker_compose_v2:

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -67,19 +67,19 @@ resource "openstack_networking_floatingip_associate_v2" "lb_fip_association" {
 }
 
 resource "openstack_lb_member_v2" "k8s_member_websecure" {
-  count         = length(local.nodes_ips)
+  count         = length(terraform_data.nodes_ips.output)
   name          = "k8s-websecure-member-${count.index}"
   pool_id       = openstack_lb_pool_v2.k8s_websecure_pool.id
-  address       = local.nodes_ips[count.index]
+  address       = terraform_data.nodes_ips.output[count.index]
   protocol_port = var.ingress_service_port_websecure
   depends_on    = [data.openstack_compute_instance_v2.instance]
 }
 
 resource "openstack_lb_member_v2" "k8s_member_web" {
-  count         = length(local.nodes_ips)
+  count         = length(terraform_data.nodes_ips.output)
   name          = "k8s-web-member-${count.index}"
   pool_id       = openstack_lb_pool_v2.k8s_web_pool.id
-  address       = local.nodes_ips[count.index]
+  address       = terraform_data.nodes_ips.output[count.index]
   protocol_port = var.ingress_service_port_web
   depends_on    = [data.openstack_compute_instance_v2.instance]
 }

--- a/terraform/ovh_kube_cluster.tf
+++ b/terraform/ovh_kube_cluster.tf
@@ -38,11 +38,10 @@ data "openstack_compute_instance_v2" "instance" {
   id    = data.ovh_cloud_project_kube_nodepool_nodes.nodes.nodes[count.index].instance_id
 }
 
-locals {
-  // List of each node IP on the app network
-  nodes_ips = flatten([
+resource "terraform_data" "nodes_ips" {
+  input = flatten([
     for instances in data.openstack_compute_instance_v2.instance : [
-      for n in instances.network : n.fixed_ip_v4 if n.name != "Ext-Net"
+      for n in instances.network : n.fixed_ip_v4 if n.name == var.app_vlan_name
     ]
   ])
 }


### PR DESCRIPTION
Using a different version of Terraform locally and on the CI provokes a mysteriously different calculation of data.openstack_compute_instance_v2.instance resource which in turn leads to the suppression or reconstruction of the members of the octavia loadbalancer.
The solution : use of the same version of terraform (1.9) between local machine and CI.